### PR TITLE
fix pio 'std::make_unique' is only available from C++14 onwards

### DIFF
--- a/platforms/esp32_pio/platformio.ini
+++ b/platforms/esp32_pio/platformio.ini
@@ -19,6 +19,9 @@ build_flags =
     -DCORE_DEBUG_LEVEL=3
     -I ../../app
 
+build_unflags =
+    -std=gnu++11  
+
 ; board_build.partitions = custom.csv
 
 ; ; 应用层


### PR DESCRIPTION
fix pio 'std::make_unique' is only available from C++14 onwards